### PR TITLE
Add aligned memory allocator

### DIFF
--- a/include/Runtime/Task/Task.hpp
+++ b/include/Runtime/Task/Task.hpp
@@ -17,6 +17,7 @@
 
 #include "Tools/Interface/Interface_clone.hpp"
 #include "Tools/Interface/Interface_reset.hpp"
+#include "Tools/System/memory.hpp"
 
 namespace aff3ct
 {
@@ -67,8 +68,9 @@ protected:
 	size_t n_output_sockets;
 	size_t n_fwd_sockets; 
 
+	typedef std::vector<uint8_t, tools::aligned_allocator<uint8_t>> buffer;
 	std::vector<int> status;
-	std::vector<std::vector<uint8_t>> out_buffers;
+	std::vector<buffer> out_buffers;
 
 	// stats
 	uint32_t                 n_calls;

--- a/include/Tools/System/memory.hpp
+++ b/include/Tools/System/memory.hpp
@@ -1,0 +1,60 @@
+/*!
+ * \file
+ * \brief Memory allocation utilities.
+ */
+#ifndef SYSTEM_MEMORY_HPP__
+#define SYSTEM_MEMORY_HPP__
+
+#include <new>
+
+namespace aff3ct
+{
+namespace tools
+{
+void* mem_alloc(std::size_t size);
+void mem_free(void* ptr);
+
+template <typename T>
+T* buffer_alloc(std::size_t nData)
+{
+	T* const ptr = reinterpret_cast<T*>(mem_alloc(nData * sizeof(T)));
+	if (!ptr)
+		throw std::bad_alloc();
+	return ptr;
+}
+
+template <typename T>
+void buffer_free(T* ptr)
+{
+	mem_free(ptr);
+}
+
+template <class T>
+struct aligned_allocator
+{
+	typedef T value_type;
+	aligned_allocator() { }
+	template <class C> aligned_allocator(const aligned_allocator<C>& other) { }
+	T* allocate(std::size_t n) { return buffer_alloc<T>(n); }
+	void deallocate(T* p, std::size_t n) { buffer_free<T>(p); }
+};
+
+// Returns true if and only if storage allocated from ma1 can be
+// deallocated from ma2, and vice versa. Always returns true for
+// stateless allocators.
+template <class C1, class C2>
+bool operator==(const aligned_allocator<C1>& ma1, const aligned_allocator<C2>& ma2)
+{
+	return true;
+}
+
+template <class C1, class C2>
+bool operator!=(const aligned_allocator<C1>& ma1, const aligned_allocator<C2>& ma2)
+{
+	return !(ma1 == ma2);
+}
+
+}
+}
+
+#endif // SYSTEM_MEMORY_HPP__

--- a/src/Runtime/Task/Task.cpp
+++ b/src/Runtime/Task/Task.cpp
@@ -80,7 +80,7 @@ void Task
 			for (auto& s : sockets)
 				if (get_socket_type(*s) == socket_t::SOUT && s->get_name() != "status")
 				{
-					out_buffers.push_back(std::vector<uint8_t>(s->databytes));
+					out_buffers.push_back(buffer(s->databytes));
 					s->dataptr = out_buffers.back().data();
 				}
 		}
@@ -642,7 +642,7 @@ size_t Task
 	// memory allocation
 	if (is_autoalloc())
 	{
-		out_buffers.push_back(std::vector<uint8_t>(s.get_databytes()));
+		out_buffers.push_back(buffer(s.get_databytes()));
 		s.dataptr = out_buffers.back().data(); // memory allocation
 	}
 

--- a/src/Tools/System/memory.cpp
+++ b/src/Tools/System/memory.cpp
@@ -1,0 +1,38 @@
+#include <cstdlib>
+#include "Tools/System/memory.hpp"
+
+namespace aff3ct
+{
+namespace tools
+{
+
+static void* mem_alloc_aligned(std::size_t alignment, std::size_t size)
+{
+	void* ptr = nullptr;
+#if __cplusplus >= 201703L
+	ptr = std::aligned_alloc(alignment, size);
+#elif defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE >= 200112L)
+	if (posix_memalign(&ptr, alignment, size) != 0)
+		ptr = nullptr;
+#else
+#error "XXX: unimplemented mem_alloc_aligned()"
+#endif
+	return ptr;
+}
+
+void* mem_alloc(std::size_t size)
+{
+	std::size_t alignment = 64; // default alignment for up to 512-bit vectors
+	// XXX: for large enough buffers (heuristics TBD), we could
+	// make the alignment a page size to allow for CPU/GPU Shared
+	// Virtual Memory (SVM) configurations
+	return mem_alloc_aligned(alignment, size);
+}
+
+void mem_free(void* ptr)
+{
+	free(ptr);
+}
+
+}
+}


### PR DESCRIPTION
Make sure to allocate aligned memory for out buffers, as they could serve as SIMD vectors. The default alignment is sufficient for up to 512-bit vectors.

Closes aff3ct/aff3ct#182